### PR TITLE
Search improvements

### DIFF
--- a/FunctionalTrader.cabal
+++ b/FunctionalTrader.cabal
@@ -79,3 +79,4 @@ Test-Suite test
   build-depends:      base >=4.12 && <4.13
                     , hspec == 2.11.10
                     , containers == 0.6.0.1
+                    , mtl == 2.2.2

--- a/FunctionalTrader.cabal
+++ b/FunctionalTrader.cabal
@@ -62,6 +62,7 @@ executable FunctionalTrader
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.12 && <4.13
                      , containers == 0.6.0.1
+                     , mtl == 2.2.2
 
   -- Directories containing source files.
   hs-source-dirs:      src

--- a/src/Sector.hs
+++ b/src/Sector.hs
@@ -66,7 +66,7 @@ getDistanceTo testFunc = do
 
   -- add adjacent sectors to the search and move on
   else do
-    let adjacent = filter (`notElem` vis) $ filter (not . isWall) $ getAllJust [up sec, down sec, left sec, right sec, warp sec]
+    let adjacent = filter (`notElem` vis) $ filter (not . isWall) $ getAllJust (map ($ sec) [up, down, left, right, warp])
     let newDists = [dist + 1 | _ <- adjacent]
     put $ Search (sec:vis) (toVis ++ adjacent) (dists ++ newDists)
     getDistanceTo testFunc

--- a/src/Sector.hs
+++ b/src/Sector.hs
@@ -52,10 +52,9 @@ getAllJust (x:xs) = (getAllJust [x]) ++ (getAllJust xs)
 getDistanceTo :: (Sector -> Bool) -> SearchState (Maybe Integer)
 getDistanceTo testFunc = do
   -- unpack the state and remove the current sector
-  search <- get
-  let vis = visited search
-  let sec:toVis = toVisit search
-  let dist:dists = distances search
+  Search vis toVisit distances <- get
+  let (sec:toVis) = toVisit
+  let (dist:dists) = distances
   put (Search vis toVis dists)
 
   -- test default cases

--- a/src/Sector.hs
+++ b/src/Sector.hs
@@ -35,7 +35,7 @@ isWall :: Sector -> Bool
 isWall Wall = True
 isWall _ = False
 
-data Search = Search { visited :: [Integer], toVisit :: [Sector], distances :: [Integer]} deriving (Show)
+data Search = Search { visited :: [Sector], toVisit :: [Sector], distances :: [Integer]} deriving (Show)
 type SearchState = State Search
 
 showNumOnly :: Maybe Sector -> String
@@ -56,20 +56,19 @@ getDistanceTo testFunc = do
   let vis = visited search
   let sec:toVis = toVisit search
   let dist:dists = distances search
-  let n = num sec
   put (Search vis toVis dists)
 
   -- test default cases
   --  if it's a wall or we've already been here, move on immediately
   --  if it satisfies the test, return the distance
-  if isWall sec || (n `elem` vis) then getDistanceTo testFunc
+  if isWall sec || (sec `elem` vis) then getDistanceTo testFunc
   else if testFunc sec then return $ Just dist
 
   -- add adjacent sectors to the search and move on
   else do
-    let adjacent = filter (\s -> num s `notElem` vis) $ filter (not . isWall) $ getAllJust [up sec, down sec, left sec, right sec, warp sec]
+    let adjacent = filter (`notElem` vis) $ filter (not . isWall) $ getAllJust [up sec, down sec, left sec, right sec, warp sec]
     let newDists = [dist + 1 | _ <- adjacent]
-    put $ Search (n:vis) (toVis ++ adjacent) (dists ++ newDists)
+    put $ Search (sec:vis) (toVis ++ adjacent) (dists ++ newDists)
     getDistanceTo testFunc
 
 newSearchState :: Sector -> Search

--- a/src/Sector.hs
+++ b/src/Sector.hs
@@ -53,22 +53,23 @@ getDistanceTo :: (Sector -> Bool) -> SearchState (Maybe Integer)
 getDistanceTo testFunc = do
   -- unpack the state and remove the current sector
   Search vis toVisit distances <- get
-  let (sec:toVis) = toVisit
-  let (dist:dists) = distances
-  put (Search vis toVis dists)
+  if null toVisit then return Nothing else do
+    let (sec:toVis) = toVisit
+    let (dist:dists) = distances
+    put (Search vis toVis dists)
 
-  -- test default cases
-  --  if it's a wall or we've already been here, move on immediately
-  --  if it satisfies the test, return the distance
-  if isWall sec || (sec `elem` vis) then getDistanceTo testFunc
-  else if testFunc sec then return $ Just dist
+    -- test default cases
+    --  if it's a wall or we've already been here, move on immediately
+    --  if it satisfies the test, return the distance
+    if isWall sec || (sec `elem` vis) then getDistanceTo testFunc
+    else if testFunc sec then return $ Just dist
 
-  -- add adjacent sectors to the search and move on
-  else do
-    let adjacent = filter (`notElem` vis) $ filter (not . isWall) $ getAllJust (map ($ sec) [up, down, left, right, warp])
-    let newDists = [dist + 1 | _ <- adjacent]
-    put $ Search (sec:vis) (toVis ++ adjacent) (dists ++ newDists)
-    getDistanceTo testFunc
+    -- add adjacent sectors to the search and move on
+    else do
+      let adjacent = filter (`notElem` vis) $ filter (not . isWall) $ getAllJust (map ($ sec) [up, down, left, right, warp])
+      let newDists = [dist + 1 | _ <- adjacent]
+      put $ Search (sec:vis) (toVis ++ adjacent) (dists ++ newDists)
+      getDistanceTo testFunc
 
 newSearchState :: Sector -> Search
 newSearchState start = Search [] [start] [0]

--- a/test/SectorSpec.hs
+++ b/test/SectorSpec.hs
@@ -73,3 +73,23 @@ spec = do
       it "returns the distance" $ do
         distanceTo sec1 (== sec2) `shouldBe` Just distance
         
+    context "when searching via a warp" $ do
+      context "when the warp is slower" $ do
+        let distance = 3
+        let secs = [Sector 0 (Just $ secs !! 1) (Just Wall) (Just Wall) (Just Wall) (Just $ secs !! fromInteger distance) 0 0 [] []]
+                   ++ [Sector (toInteger i) (Just $ secs !! (i+1)) (Just $ secs !! (i-1)) (Just Wall) (Just Wall) (Just Wall) 0 0 [] [] | i <- [1..(fromInteger distance - 1)] :: [Int]]
+                   ++ [Sector distance (Just Wall) (Just $ secs !! (fromInteger distance - 1)) (Just Wall) (Just Wall) (Just $ head secs) 0 0 [] []]
+        let sec1 = secs !! 0
+        let sec2 = secs !! fromInteger distance
+        it "returns the non-warp distance" $ do
+          distanceTo sec1 (== sec2) `shouldBe` Just distance
+
+      context "when the warp is faster" $ do
+        let distance = 20
+        let secs = [Sector 0 (Just $ secs !! 1) (Just Wall) (Just Wall) (Just Wall) (Just $ secs !! fromInteger distance) 0 0 [] []]
+                   ++ [Sector (toInteger i) (Just $ secs !! (i+1)) (Just $ secs !! (i-1)) (Just Wall) (Just Wall) (Just Wall) 0 0 [] [] | i <- [1..(fromInteger distance - 1)] :: [Int]]
+                   ++ [Sector distance (Just Wall) (Just $ secs !! (fromInteger distance - 1)) (Just Wall) (Just Wall) (Just $ head secs) 0 0 [] []]
+        let sec1 = secs !! 0
+        let sec2 = secs !! fromInteger distance
+        it "returns the warp distance" $ do
+          distanceTo sec1 (== sec2) `shouldBe` Just 5


### PR DESCRIPTION
 - **Search algorithm has been rewritten to use the State monad.** This slightly simplifies the code and the interface for the function by not requiring the state to be passed into the function call explicitly each time, and allows for some logical simplifications (e.g. we can immediately drop the head from the state, and then the function calls for the cases that don't branch are much simpler).
 - **The increased distance for using a warp (5 turns rather than 1 turn) is taken into account.** This is done by keeping `toVisit` sorted by distance at all times. This way, new warps will be pushed to the end of the list, and any adjacent sectors that would be faster than warping are inserted ahead of it. This way, the search should always explore the closest sectors first and only consider warps when all closer options have been exhausted.